### PR TITLE
build: Support plugins DSL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - secure: "u2fUNhYP22fX4GGOiipfDBzbMl/gP/16Vo9wOo67guryp/8IU2eGqE8oeot2B2kGj9Be/5S/MHftDCooE2GLJrtECbDfk1JolZLaBeq9sMIb8/vkkrIYYA881iryZbYvuWXHwoIxNe40bnzp2i0GMD3QrSWcGr9SM3nlprOET0Q/U6dIa1BQMdfU5iGT5x/9oBkkCwnU1Ro0KHIA/ZxiSDpBoGFXZ7HCJDk17UZWmAS0o7Fm8sJsmkqPIVSJ8cCParGvLOHRL5yRx6G24Z21UuzA3imrKtfrrCU3/DbynQlb2UFi1Dp4AX7xQFfsJlvEiyTH8f5xveXhY+gKqwutwzMfD4HvGJGpaBM5JjsCnakoL7FhWOYTyiKyPCPdxhkl54pwQqlC1h3yPFw2hZRyzjPxz551SmEhNi9WN2m0sbWzIwGniQsI7nTP8zqHz0+bYT2l4J2gvJdPXhdsIn1q3Nu+yX5eLK0gu40VVmVN4f+1Mc7i5jq+ZqaTD9ewxmt9hBa7OAo3uuYdS6u6DsG6uzxI4u39WjW7tbHJ8wxxAHMS94WreS5KYUJdnd0R9nok+qxAaQtyy2XU8MXaOkGD14N5e0IvO36uJj2aYyY6If/ESrGIQuD66jLYcPj131YTPMrz/oOFFAE0PGAQbttg5624Mlo+sbYZTQj9lCrx3KA="
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 # The Github user *tt-ci* is the user who will do the git commits initiated by the Gradle Release Plugin.
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+  * Allow clients to apply plugin with [plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block)
 
 **1.0.0** (2018-10-30):
   * Initial commit

--- a/README.md
+++ b/README.md
@@ -21,25 +21,47 @@ changelog file based on the released version and the release date.
       * Initial commit
     ```
 
-1. Add the Gradle plugin and configure it in *build.gradle*
-
+1. Add the Gradle plugin
+    
+    1. Using the [plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block):
+    
+    In your *setting.gradle.kts*    
+    ```kotlin
+    pluginManagement {
+        repositories {
+            maven {
+                url = "https://dl.bintray.com/tomtom-nav-pipeline/gradle-plugins"
+            }
+        }
+    }
+    ```    
+    In *build.gradle.kts*
+    ```kotlin
+    plugins {
+        id("com.tomtom.gradle.updatechangelog") version "<version>"
+    }
+    ```
+    
+    1. Using [legacy plugin application](https://docs.gradle.org/current/userguide/plugins.html#sec:old_plugin_application):
     ```gradle
     buildscript {
         repositories {
             maven {
-              url  "https://dl.bintray.com/tomtom-nav-pipeline/gradle-plugins"
+              url "https://dl.bintray.com/tomtom-nav-pipeline/gradle-plugins"
             }
         }
 
         dependencies {
-            classpath group: 'com.tomtom.gradle', name: 'updatechangelog-plugin', version: '1.0.0'
+            classpath 'com.tomtom.gradle:updatechangelog-plugin:<version>'
         }
     }
 
     apply: com.tomtom.gradle.updatechangelog
+    ```
 
-    [...]
+1. Configure it in *build.gradle*
 
+    ```groovy
     changelog {
       versionPlaceholder = '# Changelog'
       changelogFilename = 'CHANGELOG.md'

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ apply plugin: 'java-gradle-plugin'
 apply plugin: 'maven-publish'
 apply from: "$rootDir/gradle/functional-test.gradle"
 
+group = 'com.tomtom.gradle'
 
 gradlePlugin {
   plugins {
@@ -58,19 +59,10 @@ compileGroovy {
   options.warnings = true
 }
 
-publishing {
-  publications {
-    mavenJava(MavenPublication) {
-      from components.java
-      groupId = 'com.tomtom.gradle'
-    }
-  }
-}
-
 bintray {
   user = project.findProperty('bintray.user') ?: System.getProperty('bintray.user')
   key = project.findProperty('bintray.key') ?: System.getProperty('bintray.key')
-  publications = ['mavenJava', 'updateChangelogPluginMarkerMaven']
+  publications = ['pluginMaven', 'updateChangelogPluginMarkerMaven']
   publish = true //[Default: false] Whether version should be auto published after an upload
 
   pkg {

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply from: "$rootDir/gradle/functional-test.gradle"
 
 gradlePlugin {
   plugins {
-    updateChangelogPlugin {
+    updateChangelog {
       id = 'com.tomtom.gradle.updatechangelog'
       description = 'A plugin that automatically updates the version in your changelog file.'
       implementationClass = 'com.tomtom.gradle.updatechangelog.UpdateChangelogPlugin'
@@ -70,7 +70,7 @@ publishing {
 bintray {
   user = project.findProperty('bintray.user') ?: System.getProperty('bintray.user')
   key = project.findProperty('bintray.key') ?: System.getProperty('bintray.key')
-  publications = ['mavenJava']
+  publications = ['mavenJava', 'updateChangelogPluginMarkerMaven']
   publish = true //[Default: false] Whether version should be auto published after an upload
 
   pkg {

--- a/build.gradle
+++ b/build.gradle
@@ -59,10 +59,15 @@ compileGroovy {
   options.warnings = true
 }
 
+afterEvaluate {
+  def publicationNames = publishing.publications.findAll { it instanceof MavenPublication }.collect { it.name }
+  project.logger.info("Bintray publications: ${publicationNames}")
+  bintray.publications = publicationNames
+}
+
 bintray {
   user = project.findProperty('bintray.user') ?: System.getProperty('bintray.user')
   key = project.findProperty('bintray.key') ?: System.getProperty('bintray.key')
-  publications = ['pluginMaven', 'updateChangelogPluginMarkerMaven']
   publish = true //[Default: false] Whether version should be auto published after an upload
 
   pkg {

--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,9 @@ group = 'com.tomtom.gradle'
 gradlePlugin {
   plugins {
     updateChangelog {
-      id = 'com.tomtom.gradle.updatechangelog'
+      id = "${project.group}.updatechangelog"
       description = 'A plugin that automatically updates the version in your changelog file.'
-      implementationClass = 'com.tomtom.gradle.updatechangelog.UpdateChangelogPlugin'
+      implementationClass = "${project.group}.updatechangelog.UpdateChangelogPlugin"
     }
   }
 }


### PR DESCRIPTION
Currently plugin publishes only main artifact: `com.tomtom.gradle:updatechangelog-plugin:<version>`
But in order to be able to utilize [plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block) one more artifact should be published: `com.tomtom.gradle.updatechangelog:com.tomtom.gradle.updatechangelog.gradle.plugin:<version>`. This artifact will have dependency on the main plugin artifact and will not contain anything but `.pom` file. 
When Gradle tries to resolve Plugin artifact from provided ID, it constructs it in next way: `<pluginID>:<pluginID>.gradle.plugin:<version>` by default.

The `java-gradle-plugin` is used to define information about the `updatechangelog` plugin publication. It also creates two Maven publications, which satisfy requirements above. One of them is copy of `mavenJava`, which is deleted with changes in this PR. Maven publications use project's group name by default, so the name was specified to the project scope.