### PR TITLE
docs: Fix Maven repository URLs, add empty lines before code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,19 @@ changelog file based on the released version and the release date.
     1. Using the [plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block):
     
     In your *setting.gradle.kts*    
+    
     ```kotlin
     pluginManagement {
         repositories {
             maven {
-                url = "https://dl.bintray.com/tomtom-nav-pipeline/gradle-plugins"
+                url = "https://dl.bintray.com/tomtom-international/gradle-plugins"
             }
         }
     }
     ```    
+    
     In *build.gradle.kts*
+    
     ```kotlin
     plugins {
         id("com.tomtom.gradle.updatechangelog") version "<version>"
@@ -43,11 +46,12 @@ changelog file based on the released version and the release date.
     ```
     
     1. Using [legacy plugin application](https://docs.gradle.org/current/userguide/plugins.html#sec:old_plugin_application):
-    ```gradle
+    
+    ```groovy
     buildscript {
         repositories {
             maven {
-              url "https://dl.bintray.com/tomtom-nav-pipeline/gradle-plugins"
+              url "https://dl.bintray.com/tomtom-international/gradle-plugins"
             }
         }
 


### PR DESCRIPTION
Maven repository URL mentioned in Readme file is was outdated. 
Now it points to the correct Bintray repository.
Also added empty lines before code blocks for consistency.